### PR TITLE
Fix multiple bugs: panics, wrong list indexing, redundant terminal, c…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,12 +34,17 @@ impl StatefulList {
         self.state.select(None);
     }
 
-    /// # Panics
-    ///
     pub fn next(&mut self) {
+        let len = self
+            .filtered
+            .as_ref()
+            .map_or(0, |f| f.len());
+        if len == 0 {
+            return;
+        }
         let i = match self.state.selected() {
             Some(i) => {
-                if i >= self.filtered.clone().unwrap().len() - 1 {
+                if i >= len - 1 {
                     0
                 } else {
                     i + 1
@@ -51,10 +56,17 @@ impl StatefulList {
     }
 
     pub fn previous(&mut self) {
+        let len = self
+            .filtered
+            .as_ref()
+            .map_or(0, |f| f.len());
+        if len == 0 {
+            return;
+        }
         let i = match self.state.selected() {
             Some(i) => {
                 if i == 0 {
-                    self.items.len() - 1
+                    len - 1
                 } else {
                     i - 1
                 }
@@ -78,12 +90,8 @@ impl App {
         }
     }
     pub fn select_first_item_if_none(&mut self) {
-        match self.items.state.selected() {
-            None => {
-                // no selection. select the first.
-                self.items.state.select(Some(0));
-            }
-            Some(_) => {}
+        if self.items.state.selected().is_none() {
+            self.items.state.select(Some(0));
         }
     }
 
@@ -136,7 +144,7 @@ impl App {
                 if self.filter.is_empty() {
                     true
                 } else {
-                    x.branch_name.to_lowercase().contains(&self.filter)
+                    x.branch_name.to_lowercase().contains(&self.filter.to_lowercase())
                 }
             })
             .collect();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,17 @@
 use githist::git::branching::{get_branch_names, Config};
 use githist::ui::gui::{restore_terminal, setup_terminal};
 use githist::App;
-use ratatui::backend::CrosstermBackend;
-use ratatui::Terminal;
 use std::error::Error;
-use std::{env, io};
+use std::env;
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
     let config = Config::new(&args);
-    let stdout = io::stdout();
-    let backend = CrosstermBackend::new(stdout);
-    let mut terminal = Terminal::new(backend)?;
 
     match get_branch_names(&config) {
         Ok(result) => {
-            setup_terminal();
-            let vec = result;
-            let mut app = App::new(vec);
+            let mut terminal = setup_terminal();
+            let mut app = App::new(result);
             app.select_first_item_if_none();
             let res = app.run_app(&config, &mut terminal);
             if let Err(err) = res {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -53,13 +53,13 @@ pub mod gui {
                 .iter()
                 .map(|x| x.branch_name.len())
                 .max()
-                .unwrap();
+                .unwrap_or(0);
 
             let items: Vec<ListItem> = self
                 .items
                 .filtered
                 .clone()
-                .unwrap_or(Box::default())
+                .unwrap_or_default()
                 .into_iter()
                 .map(|branch_info| {
                     let branch_and_padding =


### PR DESCRIPTION
…ase filter

- Fix previous() using unfiltered items.len() instead of filtered list length, causing index out of bounds when navigating up while filtering
- Fix next() panic from unwrap() on None when filtered list is empty
- Fix previous()/next() underflow panic (usize 0 - 1) on empty lists by adding early return guards
- Fix ui() panic from .max().unwrap() on empty branch list
- Fix main.rs discarding terminal from setup_terminal() and creating a redundant one that bypassed raw mode/alternate screen setup
- Fix case-inconsistent filter: branch names were lowercased but filter text was not, so uppercase input never matched
- Address clippy warnings (unwrap_or_default, single_match)

https://claude.ai/code/session_013N8DGDrGDJwcqSBZvCXuE5